### PR TITLE
fix: delete extra div in participant summary

### DIFF
--- a/app/views/participants/_participant_summary.html.erb
+++ b/app/views/participants/_participant_summary.html.erb
@@ -11,7 +11,5 @@
                   event_path(participant.event_id),
                   method: :get,
                   class:"btn btn-outline-primary" %>
-
-    </div>
   </div>
 </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] General Task

## Description

Extra Div in participant summary made profile look weird

## Related Tickets & Documents

- Related Issue #
- Closes #

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: just took out an extra div
- [ ] I need help with writing tests
